### PR TITLE
Fixed catalog.yml to avoid Genie database name parsing error 🎯

### DIFF
--- a/catalog.yml
+++ b/catalog.yml
@@ -1,6 +1,6 @@
-unique_name: TPC-DS Benchmark Model - DB
+unique_name: TPC-DS_Benchmark_Model-DB
 object_type: catalog
-label: TPC-DS Benchmark Model - DB
+label: TPC-DS_Benchmark_Model-DB
 version: 1.0
 aggressive_agg_promotion: false
 build_speculative_aggs: false


### PR DESCRIPTION
John Lynch can confirm that Databricks fails to parse names with spaces in it. 

Query Name comes from unique_name field in catalog.yml